### PR TITLE
Corrections to gremlin csv format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ Graph Machine Learning with Amazon Neptune ML involves five main steps:
 5. **Querying the ML Model using Gremlin** – You can use extensions to the Gremlin query language to query predictions from the inference endpoint.
 
 ## Running Code
-1. As an initial step, run through `create-graph-dataset.ipynb` notebook to generate and load the graph dataset to an Amazon Neptune cluster.
-2. Use the `detect-fake-news-neptune-ml.ipynb` notebook to run through steps 1 to 5 above of graph machine learning with Amazon Neptune ML an interactive way.
+1. As an initial step, run through `create-graph-dataset.ipynb` notebook to generate the graph dataset.
+2. Use the `load-graph-dataset.ipynb` notebook to load the graph dataset to an Amazon Neptune cluster.
+3. Use the `detect-fake-news-neptune-ml.ipynb` notebook to run through steps 1 to 5 above of graph machine learning with Amazon Neptune ML an interactive way.
 
-Note: Use this [QuickStart CloudFormation template](https://docs.aws.amazon.com/neptune/latest/userguide/machine-learning-quick-start.html) to quickly spin up a `graph-notebook`, an associted Neptune cluster, and set up all the configurations needed to work with Neptune ML in a `graph-notebook`. 
+Note: Use this [QuickStart CloudFormation template](https://docs.aws.amazon.com/neptune/latest/userguide/machine-learning-quick-start.html) to quickly spin up a `graph-notebook`, an associted Neptune cluster, and set up all the configurations needed to work with Neptune ML in a `graph-notebook`. To run the `create-graph-dataset.ipynb` notebook select a NotebookInstanceType of `ml.c5.9xlarge` to ensure you have enough memory to load the `UserFeature.mat` file.
 
 ## Security
 

--- a/create-graph-dataset.ipynb
+++ b/create-graph-dataset.ipynb
@@ -31,19 +31,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "id": "1de76750",
    "metadata": {},
    "outputs": [],
    "source": [
     "# import required libraries\n",
     "import pandas as pd\n",
+    "import numpy as np\n",
     "import scipy.io\n",
     "import json\n",
     "import numpy as np\n",
     "from sklearn.decomposition import PCA\n",
     "from sklearn.preprocessing import StandardScaler\n",
     "import boto3\n",
+    "import sagemaker\n",
     "import utils.neptune_ml_utils as neptune_ml"
    ]
   },
@@ -65,7 +67,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
+   "id": "241a35c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "REPO=$(pwd)\n",
+    "cd ../\n",
+    "git clone https://github.com/KaiDMML/FakeNewsNet\n",
+    "cd FakeNewsNet\n",
+    "git checkout old-version\n",
+    "cd $REPO\n",
+    "cp -r ../FakeNewsNet/Data/* ./Data/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "799c7429",
    "metadata": {},
    "outputs": [],
@@ -76,73 +96,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "d226af28",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>98d2b98ce305174e2f6c10b8f8a1a9d5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>a273d0fd07c18a884ce2aa425813eb06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>ac091e92df9e854a07563ffb397925d4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>d2ded2de054f2ceb43dff7f80fc46774</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>3f2b23abf0e842f6bc97eed85596ff50</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                  0\n",
-       "0  98d2b98ce305174e2f6c10b8f8a1a9d5\n",
-       "1  a273d0fd07c18a884ce2aa425813eb06\n",
-       "2  ac091e92df9e854a07563ffb397925d4\n",
-       "3  d2ded2de054f2ceb43dff7f80fc46774\n",
-       "4  3f2b23abf0e842f6bc97eed85596ff50"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "users.head()"
    ]
@@ -157,21 +114,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "73047ca5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(15257, 1)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "users.shape"
    ]
@@ -186,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "4551a65e",
    "metadata": {},
    "outputs": [],
@@ -197,73 +143,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "e7e3c132",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>BuzzFeed_Real_1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>BuzzFeed_Real_2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BuzzFeed_Real_3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>BuzzFeed_Real_4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>BuzzFeed_Real_5</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                 0\n",
-       "0  BuzzFeed_Real_1\n",
-       "1  BuzzFeed_Real_2\n",
-       "2  BuzzFeed_Real_3\n",
-       "3  BuzzFeed_Real_4\n",
-       "4  BuzzFeed_Real_5"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "news.head()"
    ]
@@ -278,21 +161,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "3832f5df",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(182, 1)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "news.shape"
    ]
@@ -307,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "faf33dc5",
    "metadata": {},
    "outputs": [],
@@ -318,85 +190,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "908721bb",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>1</th>\n",
-       "      <th>2</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>45</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>127</td>\n",
-       "      <td>2</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>115</td>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>180</td>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>140</td>\n",
-       "      <td>4</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "     0  1  2\n",
-       "0   45  1  1\n",
-       "1  127  2  1\n",
-       "2  115  3  1\n",
-       "3  180  3  1\n",
-       "4  140  4  1"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "news_user.head()"
    ]
@@ -411,42 +208,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "0e22ad0a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(22779, 3)"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "news_user.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "2ad7682e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "25240"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "news_user[2].sum()"
    ]
@@ -461,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "e020eaef",
    "metadata": {},
    "outputs": [],
@@ -472,79 +247,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "c216feaa",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>1</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>48</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>899</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>6781</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>10097</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>100</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "       0  1\n",
-       "0     48  1\n",
-       "1    899  1\n",
-       "2   6781  1\n",
-       "3  10097  1\n",
-       "4    100  2"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "user_user.head()"
    ]
@@ -559,21 +265,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "8369a815",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(634750, 2)"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "user_user.shape"
    ]
@@ -588,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "d0a7cbe2",
    "metadata": {},
    "outputs": [],
@@ -599,21 +294,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "0adde73e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(15257, 109626)"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "user_features.shape"
    ]
@@ -628,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "ec80369a",
    "metadata": {},
    "outputs": [],
@@ -658,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "2812b9c6",
    "metadata": {},
    "outputs": [],
@@ -670,117 +354,23 @@
     "# add user_features as a property for each user node\n",
     "users['user_features:Double[]'] = np.nan\n",
     "for i, r in users.iterrows():\n",
-    "    string = \";\".join([str(val) for val in X_pca[i,:]])\n",
+    "    string = \";\".join([format(val,'.53f') for val in X_pca[i,:]])\n",
     "    users.loc[i, 'user_features:Double[]'] = string"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "75dd7329",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>row_num</th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>user_features:Double[]</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>98d2b98ce305174e2f6c10b8f8a1a9d5</td>\n",
-       "      <td>0</td>\n",
-       "      <td>user_1</td>\n",
-       "      <td>user</td>\n",
-       "      <td>-6.5335629813853275;-2.539568976534804;-0.0862...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>a273d0fd07c18a884ce2aa425813eb06</td>\n",
-       "      <td>1</td>\n",
-       "      <td>user_2</td>\n",
-       "      <td>user</td>\n",
-       "      <td>3.7452664109727127;-2.3658738836989692;0.37171...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>ac091e92df9e854a07563ffb397925d4</td>\n",
-       "      <td>2</td>\n",
-       "      <td>user_3</td>\n",
-       "      <td>user</td>\n",
-       "      <td>-6.169060740831697;-0.4554150240050502;-2.0617...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>d2ded2de054f2ceb43dff7f80fc46774</td>\n",
-       "      <td>3</td>\n",
-       "      <td>user_4</td>\n",
-       "      <td>user</td>\n",
-       "      <td>11.19523153278209;-1.182848759491067;0.3934020...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>3f2b23abf0e842f6bc97eed85596ff50</td>\n",
-       "      <td>4</td>\n",
-       "      <td>user_5</td>\n",
-       "      <td>user</td>\n",
-       "      <td>-6.182361512218626;0.4971749514792787;-0.91511...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                  0  row_num     ~id ~label  \\\n",
-       "0  98d2b98ce305174e2f6c10b8f8a1a9d5        0  user_1   user   \n",
-       "1  a273d0fd07c18a884ce2aa425813eb06        1  user_2   user   \n",
-       "2  ac091e92df9e854a07563ffb397925d4        2  user_3   user   \n",
-       "3  d2ded2de054f2ceb43dff7f80fc46774        3  user_4   user   \n",
-       "4  3f2b23abf0e842f6bc97eed85596ff50        4  user_5   user   \n",
-       "\n",
-       "                              user_features:Double[]  \n",
-       "0  -6.5335629813853275;-2.539568976534804;-0.0862...  \n",
-       "1  3.7452664109727127;-2.3658738836989692;0.37171...  \n",
-       "2  -6.169060740831697;-0.4554150240050502;-2.0617...  \n",
-       "3  11.19523153278209;-1.182848759491067;0.3934020...  \n",
-       "4  -6.182361512218626;0.4971749514792787;-0.91511...  "
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "users.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "5be61eca",
    "metadata": {},
    "outputs": [],
@@ -795,201 +385,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "ba21205d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>row_num</th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>news_type:String</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>BuzzFeed_Real_1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>news_1</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>BuzzFeed_Real_2</td>\n",
-       "      <td>1</td>\n",
-       "      <td>news_2</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BuzzFeed_Real_3</td>\n",
-       "      <td>2</td>\n",
-       "      <td>news_3</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>BuzzFeed_Real_4</td>\n",
-       "      <td>3</td>\n",
-       "      <td>news_4</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>BuzzFeed_Real_5</td>\n",
-       "      <td>4</td>\n",
-       "      <td>news_5</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                 0  row_num     ~id ~label news_type:String\n",
-       "0  BuzzFeed_Real_1        0  news_1   news             Real\n",
-       "1  BuzzFeed_Real_2        1  news_2   news             Real\n",
-       "2  BuzzFeed_Real_3        2  news_3   news             Real\n",
-       "3  BuzzFeed_Real_4        3  news_4   news             Real\n",
-       "4  BuzzFeed_Real_5        4  news_5   news             Real"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "news.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "75653980",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>row_num</th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>news_type:String</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>177</th>\n",
-       "      <td>BuzzFeed_Fake_87</td>\n",
-       "      <td>177</td>\n",
-       "      <td>news_178</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Fake</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>178</th>\n",
-       "      <td>BuzzFeed_Fake_88</td>\n",
-       "      <td>178</td>\n",
-       "      <td>news_179</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Fake</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>179</th>\n",
-       "      <td>BuzzFeed_Fake_89</td>\n",
-       "      <td>179</td>\n",
-       "      <td>news_180</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Fake</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>180</th>\n",
-       "      <td>BuzzFeed_Fake_90</td>\n",
-       "      <td>180</td>\n",
-       "      <td>news_181</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Fake</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>181</th>\n",
-       "      <td>BuzzFeed_Fake_91</td>\n",
-       "      <td>181</td>\n",
-       "      <td>news_182</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Fake</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                    0  row_num       ~id ~label news_type:String\n",
-       "177  BuzzFeed_Fake_87      177  news_178   news             Fake\n",
-       "178  BuzzFeed_Fake_88      178  news_179   news             Fake\n",
-       "179  BuzzFeed_Fake_89      179  news_180   news             Fake\n",
-       "180  BuzzFeed_Fake_90      180  news_181   news             Fake\n",
-       "181  BuzzFeed_Fake_91      181  news_182   news             Fake"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "news.tail()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "1714e9d8",
    "metadata": {},
    "outputs": [],
@@ -1002,7 +418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "548904d2",
    "metadata": {},
    "outputs": [],
@@ -1013,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "03adc4e9",
    "metadata": {},
    "outputs": [],
@@ -1051,131 +467,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "fc1fa0f8",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>row_num</th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>news_type:String</th>\n",
-       "      <th>news_title:String</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>BuzzFeed_Real_1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>news_1</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "      <td>Another Terrorist Attack in NYC…Why Are we STI...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>BuzzFeed_Real_2</td>\n",
-       "      <td>1</td>\n",
-       "      <td>news_2</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "      <td>Hillary Clinton on police shootings: 'too many...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>BuzzFeed_Real_3</td>\n",
-       "      <td>2</td>\n",
-       "      <td>news_3</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "      <td>Critical counties: Wake County, NC, could put ...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>BuzzFeed_Real_4</td>\n",
-       "      <td>3</td>\n",
-       "      <td>news_4</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "      <td>NFL Superstar Unleashes 4 Word Bombshell on Re...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>BuzzFeed_Real_5</td>\n",
-       "      <td>4</td>\n",
-       "      <td>news_5</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "      <td>Obama in NYC: 'We all have a role to play' in ...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                 0  row_num     ~id ~label news_type:String  \\\n",
-       "0  BuzzFeed_Real_1        0  news_1   news             Real   \n",
-       "1  BuzzFeed_Real_2        1  news_2   news             Real   \n",
-       "2  BuzzFeed_Real_3        2  news_3   news             Real   \n",
-       "3  BuzzFeed_Real_4        3  news_4   news             Real   \n",
-       "4  BuzzFeed_Real_5        4  news_5   news             Real   \n",
-       "\n",
-       "                                   news_title:String  \n",
-       "0  Another Terrorist Attack in NYC…Why Are we STI...  \n",
-       "1  Hillary Clinton on police shootings: 'too many...  \n",
-       "2  Critical counties: Wake County, NC, could put ...  \n",
-       "3  NFL Superstar Unleashes 4 Word Bombshell on Re...  \n",
-       "4  Obama in NYC: 'We all have a role to play' in ...  "
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "news.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "ab229dab",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "28"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(publishers_list)"
    ]
@@ -1190,46 +495,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "d7eded5f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['http://eaglerising.com',\n",
-       " 'http://cnn.it',\n",
-       " 'http://conservativebyte.com',\n",
-       " 'http://politi.co',\n",
-       " 'http://abcn.ws']"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "publishers_list[:5]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "56927ad1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "126"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(authors_list)"
    ]
@@ -1244,28 +523,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "ed2df2fe",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Leonora Cravotta', 'Mj Lee', 'Joyce Tseng', 'Eli Watkins', 'Kevin Liptak']"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "authors_list[:5]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "e0d01424",
    "metadata": {},
    "outputs": [],
@@ -1305,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "e5820205",
    "metadata": {},
    "outputs": [],
@@ -1320,106 +588,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "cde037ae",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>row_num</th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>author_name:String</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Leonora Cravotta</td>\n",
-       "      <td>0</td>\n",
-       "      <td>author_1</td>\n",
-       "      <td>author</td>\n",
-       "      <td>Leonora Cravotta</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Mj Lee</td>\n",
-       "      <td>1</td>\n",
-       "      <td>author_2</td>\n",
-       "      <td>author</td>\n",
-       "      <td>Mj Lee</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Joyce Tseng</td>\n",
-       "      <td>2</td>\n",
-       "      <td>author_3</td>\n",
-       "      <td>author</td>\n",
-       "      <td>Joyce Tseng</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Eli Watkins</td>\n",
-       "      <td>3</td>\n",
-       "      <td>author_4</td>\n",
-       "      <td>author</td>\n",
-       "      <td>Eli Watkins</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Kevin Liptak</td>\n",
-       "      <td>4</td>\n",
-       "      <td>author_5</td>\n",
-       "      <td>author</td>\n",
-       "      <td>Kevin Liptak</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                  0  row_num       ~id  ~label author_name:String\n",
-       "0  Leonora Cravotta        0  author_1  author   Leonora Cravotta\n",
-       "1            Mj Lee        1  author_2  author             Mj Lee\n",
-       "2       Joyce Tseng        2  author_3  author        Joyce Tseng\n",
-       "3       Eli Watkins        3  author_4  author        Eli Watkins\n",
-       "4      Kevin Liptak        4  author_5  author       Kevin Liptak"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "authors_df.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "af616792",
    "metadata": {},
    "outputs": [],
@@ -1434,111 +613,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "eac27cce",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>0</th>\n",
-       "      <th>row_num</th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>publisher_website:String</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>http://eaglerising.com</td>\n",
-       "      <td>0</td>\n",
-       "      <td>publisher_1</td>\n",
-       "      <td>publisher</td>\n",
-       "      <td>http://eaglerising.com</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>http://cnn.it</td>\n",
-       "      <td>1</td>\n",
-       "      <td>publisher_2</td>\n",
-       "      <td>publisher</td>\n",
-       "      <td>http://cnn.it</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>http://conservativebyte.com</td>\n",
-       "      <td>2</td>\n",
-       "      <td>publisher_3</td>\n",
-       "      <td>publisher</td>\n",
-       "      <td>http://conservativebyte.com</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>http://politi.co</td>\n",
-       "      <td>3</td>\n",
-       "      <td>publisher_4</td>\n",
-       "      <td>publisher</td>\n",
-       "      <td>http://politi.co</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>http://abcn.ws</td>\n",
-       "      <td>4</td>\n",
-       "      <td>publisher_5</td>\n",
-       "      <td>publisher</td>\n",
-       "      <td>http://abcn.ws</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                             0  row_num          ~id     ~label  \\\n",
-       "0       http://eaglerising.com        0  publisher_1  publisher   \n",
-       "1                http://cnn.it        1  publisher_2  publisher   \n",
-       "2  http://conservativebyte.com        2  publisher_3  publisher   \n",
-       "3             http://politi.co        3  publisher_4  publisher   \n",
-       "4               http://abcn.ws        4  publisher_5  publisher   \n",
-       "\n",
-       "      publisher_website:String  \n",
-       "0       http://eaglerising.com  \n",
-       "1                http://cnn.it  \n",
-       "2  http://conservativebyte.com  \n",
-       "3             http://politi.co  \n",
-       "4               http://abcn.ws  "
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "publishers_df.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "598f1ae2",
    "metadata": {},
    "outputs": [],
@@ -1549,7 +634,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "ea645938",
    "metadata": {},
    "outputs": [],
@@ -1560,21 +645,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "fe5c6a1d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(15593, 7)"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nodes.shape"
    ]
@@ -1589,123 +663,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "c6bd77f7",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>news_type:String</th>\n",
-       "      <th>news_title:String</th>\n",
-       "      <th>user_features:Double[]</th>\n",
-       "      <th>publisher_website:String</th>\n",
-       "      <th>author_name:String</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>182</th>\n",
-       "      <td>user_1</td>\n",
-       "      <td>user</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>-6.5335629813853275;-2.539568976534804;-0.0862...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>183</th>\n",
-       "      <td>user_2</td>\n",
-       "      <td>user</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>3.7452664109727127;-2.3658738836989692;0.37171...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>184</th>\n",
-       "      <td>user_3</td>\n",
-       "      <td>user</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>-6.169060740831697;-0.4554150240050502;-2.0617...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>185</th>\n",
-       "      <td>user_4</td>\n",
-       "      <td>user</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>11.19523153278209;-1.182848759491067;0.3934020...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>186</th>\n",
-       "      <td>user_5</td>\n",
-       "      <td>user</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>-6.182361512218626;0.4971749514792787;-0.91511...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "        ~id ~label news_type:String news_title:String  \\\n",
-       "182  user_1   user              NaN               NaN   \n",
-       "183  user_2   user              NaN               NaN   \n",
-       "184  user_3   user              NaN               NaN   \n",
-       "185  user_4   user              NaN               NaN   \n",
-       "186  user_5   user              NaN               NaN   \n",
-       "\n",
-       "                                user_features:Double[]  \\\n",
-       "182  -6.5335629813853275;-2.539568976534804;-0.0862...   \n",
-       "183  3.7452664109727127;-2.3658738836989692;0.37171...   \n",
-       "184  -6.169060740831697;-0.4554150240050502;-2.0617...   \n",
-       "185  11.19523153278209;-1.182848759491067;0.3934020...   \n",
-       "186  -6.182361512218626;0.4971749514792787;-0.91511...   \n",
-       "\n",
-       "    publisher_website:String author_name:String  \n",
-       "182                      NaN                NaN  \n",
-       "183                      NaN                NaN  \n",
-       "184                      NaN                NaN  \n",
-       "185                      NaN                NaN  \n",
-       "186                      NaN                NaN  "
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# user nodes\n",
     "nodes.loc[nodes['~label']=='user'].head()"
@@ -1713,123 +674,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "7630693a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>news_type:String</th>\n",
-       "      <th>news_title:String</th>\n",
-       "      <th>user_features:Double[]</th>\n",
-       "      <th>publisher_website:String</th>\n",
-       "      <th>author_name:String</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>news_1</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "      <td>Another Terrorist Attack in NYC…Why Are we STI...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>news_2</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "      <td>Hillary Clinton on police shootings: 'too many...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>news_3</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "      <td>Critical counties: Wake County, NC, could put ...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>news_4</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "      <td>NFL Superstar Unleashes 4 Word Bombshell on Re...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>news_5</td>\n",
-       "      <td>news</td>\n",
-       "      <td>Real</td>\n",
-       "      <td>Obama in NYC: 'We all have a role to play' in ...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "      ~id ~label news_type:String  \\\n",
-       "0  news_1   news             Real   \n",
-       "1  news_2   news             Real   \n",
-       "2  news_3   news             Real   \n",
-       "3  news_4   news             Real   \n",
-       "4  news_5   news             Real   \n",
-       "\n",
-       "                                   news_title:String user_features:Double[]  \\\n",
-       "0  Another Terrorist Attack in NYC…Why Are we STI...                    NaN   \n",
-       "1  Hillary Clinton on police shootings: 'too many...                    NaN   \n",
-       "2  Critical counties: Wake County, NC, could put ...                    NaN   \n",
-       "3  NFL Superstar Unleashes 4 Word Bombshell on Re...                    NaN   \n",
-       "4  Obama in NYC: 'We all have a role to play' in ...                    NaN   \n",
-       "\n",
-       "  publisher_website:String author_name:String  \n",
-       "0                      NaN                NaN  \n",
-       "1                      NaN                NaN  \n",
-       "2                      NaN                NaN  \n",
-       "3                      NaN                NaN  \n",
-       "4                      NaN                NaN  "
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# news nodes\n",
     "nodes.loc[nodes['~label']=='news'].head()"
@@ -1837,116 +685,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "8cacdae6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>news_type:String</th>\n",
-       "      <th>news_title:String</th>\n",
-       "      <th>user_features:Double[]</th>\n",
-       "      <th>publisher_website:String</th>\n",
-       "      <th>author_name:String</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>15439</th>\n",
-       "      <td>publisher_1</td>\n",
-       "      <td>publisher</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>http://eaglerising.com</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15440</th>\n",
-       "      <td>publisher_2</td>\n",
-       "      <td>publisher</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>http://cnn.it</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15441</th>\n",
-       "      <td>publisher_3</td>\n",
-       "      <td>publisher</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>http://conservativebyte.com</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15442</th>\n",
-       "      <td>publisher_4</td>\n",
-       "      <td>publisher</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>http://politi.co</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15443</th>\n",
-       "      <td>publisher_5</td>\n",
-       "      <td>publisher</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>http://abcn.ws</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "               ~id     ~label news_type:String news_title:String  \\\n",
-       "15439  publisher_1  publisher              NaN               NaN   \n",
-       "15440  publisher_2  publisher              NaN               NaN   \n",
-       "15441  publisher_3  publisher              NaN               NaN   \n",
-       "15442  publisher_4  publisher              NaN               NaN   \n",
-       "15443  publisher_5  publisher              NaN               NaN   \n",
-       "\n",
-       "      user_features:Double[]     publisher_website:String author_name:String  \n",
-       "15439                    NaN       http://eaglerising.com                NaN  \n",
-       "15440                    NaN                http://cnn.it                NaN  \n",
-       "15441                    NaN  http://conservativebyte.com                NaN  \n",
-       "15442                    NaN             http://politi.co                NaN  \n",
-       "15443                    NaN               http://abcn.ws                NaN  "
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# publisher nodes\n",
     "nodes.loc[nodes['~label']=='publisher'].head()"
@@ -1954,116 +696,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "dc2ebb8e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>news_type:String</th>\n",
-       "      <th>news_title:String</th>\n",
-       "      <th>user_features:Double[]</th>\n",
-       "      <th>publisher_website:String</th>\n",
-       "      <th>author_name:String</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>15467</th>\n",
-       "      <td>author_1</td>\n",
-       "      <td>author</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Leonora Cravotta</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15468</th>\n",
-       "      <td>author_2</td>\n",
-       "      <td>author</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Mj Lee</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15469</th>\n",
-       "      <td>author_3</td>\n",
-       "      <td>author</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Joyce Tseng</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15470</th>\n",
-       "      <td>author_4</td>\n",
-       "      <td>author</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Eli Watkins</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15471</th>\n",
-       "      <td>author_5</td>\n",
-       "      <td>author</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Kevin Liptak</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "            ~id  ~label news_type:String news_title:String  \\\n",
-       "15467  author_1  author              NaN               NaN   \n",
-       "15468  author_2  author              NaN               NaN   \n",
-       "15469  author_3  author              NaN               NaN   \n",
-       "15470  author_4  author              NaN               NaN   \n",
-       "15471  author_5  author              NaN               NaN   \n",
-       "\n",
-       "      user_features:Double[] publisher_website:String author_name:String  \n",
-       "15467                    NaN                      NaN   Leonora Cravotta  \n",
-       "15468                    NaN                      NaN             Mj Lee  \n",
-       "15469                    NaN                      NaN        Joyce Tseng  \n",
-       "15470                    NaN                      NaN        Eli Watkins  \n",
-       "15471                    NaN                      NaN       Kevin Liptak  "
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# author nodes\n",
     "nodes.loc[nodes['~label']=='author'].head()"
@@ -2079,7 +715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "925052c3",
    "metadata": {},
    "outputs": [],
@@ -2105,7 +741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "id": "ee4e2198",
    "metadata": {},
    "outputs": [],
@@ -2116,215 +752,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "id": "d37a555c",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~from</th>\n",
-       "      <th>~to</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>weight:Int</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>user_user_1</td>\n",
-       "      <td>user_48</td>\n",
-       "      <td>user_1</td>\n",
-       "      <td>follows</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>user_user_2</td>\n",
-       "      <td>user_899</td>\n",
-       "      <td>user_1</td>\n",
-       "      <td>follows</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>user_user_3</td>\n",
-       "      <td>user_6781</td>\n",
-       "      <td>user_1</td>\n",
-       "      <td>follows</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>user_user_4</td>\n",
-       "      <td>user_10097</td>\n",
-       "      <td>user_1</td>\n",
-       "      <td>follows</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>user_user_5</td>\n",
-       "      <td>user_100</td>\n",
-       "      <td>user_2</td>\n",
-       "      <td>follows</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           ~id       ~from     ~to   ~label  weight:Int\n",
-       "0  user_user_1     user_48  user_1  follows         NaN\n",
-       "1  user_user_2    user_899  user_1  follows         NaN\n",
-       "2  user_user_3   user_6781  user_1  follows         NaN\n",
-       "3  user_user_4  user_10097  user_1  follows         NaN\n",
-       "4  user_user_5    user_100  user_2  follows         NaN"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "edges.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "d2eaa332",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>~id</th>\n",
-       "      <th>~from</th>\n",
-       "      <th>~to</th>\n",
-       "      <th>~label</th>\n",
-       "      <th>weight:Int</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>634750</th>\n",
-       "      <td>news_user_1</td>\n",
-       "      <td>news_45</td>\n",
-       "      <td>user_1</td>\n",
-       "      <td>spread_by</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>634751</th>\n",
-       "      <td>news_user_2</td>\n",
-       "      <td>news_127</td>\n",
-       "      <td>user_2</td>\n",
-       "      <td>spread_by</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>634752</th>\n",
-       "      <td>news_user_3</td>\n",
-       "      <td>news_115</td>\n",
-       "      <td>user_3</td>\n",
-       "      <td>spread_by</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>634753</th>\n",
-       "      <td>news_user_4</td>\n",
-       "      <td>news_180</td>\n",
-       "      <td>user_3</td>\n",
-       "      <td>spread_by</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>634754</th>\n",
-       "      <td>news_user_5</td>\n",
-       "      <td>news_140</td>\n",
-       "      <td>user_4</td>\n",
-       "      <td>spread_by</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                ~id     ~from     ~to     ~label  weight:Int\n",
-       "634750  news_user_1   news_45  user_1  spread_by         1.0\n",
-       "634751  news_user_2  news_127  user_2  spread_by         1.0\n",
-       "634752  news_user_3  news_115  user_3  spread_by         1.0\n",
-       "634753  news_user_4  news_180  user_3  spread_by         1.0\n",
-       "634754  news_user_5  news_140  user_4  spread_by         1.0"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "edges.loc[edges['~label']=='spread_by'].head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "dc6c9af2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(658203, 5)"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "edges.shape"
    ]
@@ -2347,7 +798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "id": "25145af6",
    "metadata": {},
    "outputs": [],
@@ -2357,7 +808,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
+   "id": "e0d28cc3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "        \n",
+    "nodes['user_features:Double[]'] = nodes['user_features:Double[]'].fillna(\"\")\n",
+    "edges['weight:Int'] = edges['weight:Int'].fillna(1).apply(lambda gi:str(int(gi)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "b064eab6",
    "metadata": {},
    "outputs": [],
@@ -2367,7 +831,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "id": "37d646a4",
    "metadata": {},
    "outputs": [],
@@ -2385,19 +849,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
-   "id": "2ec5e208",
+   "execution_count": null,
+   "id": "53b32fee",
    "metadata": {},
    "outputs": [],
    "source": [
-    "bucket = '<bucket-name>'\n",
+    "sess = sagemaker.Session()\n",
+    "bucket = sess.default_bucket()\n",
+    "bucket = bucket #'<bucket-name>'\n",
     "prefix = 'fake-news-detection/data'\n",
     "s3_client = boto3.client('s3')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "id": "5f34b86f",
    "metadata": {},
    "outputs": [],
@@ -2407,115 +873,9 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "60e79928",
-   "metadata": {},
-   "source": [
-    "## Bulk Load to Neptune "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d96d8fd8",
-   "metadata": {},
-   "source": [
-    "We use the `%load` magic command which is available as part of the AWS `graph-notebook` to bulk load data to our Neptune database. You can use the `%graph_notebook_config` magic command to see information about the Neptune cluster associated with your graph-notebook, and `%status` magic command to see the status of your Neptune cluster.\n",
-    "\n",
-    "Note: Use [these CloudFormation templates](https://docs.aws.amazon.com/neptune/latest/userguide/machine-learning-quick-start.html) to quickly spin up a `graph-notebook`, an associted Neptune cluster, and set up all the configurations needed to work with Neptune ML in a `graph-notebook`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 63,
-   "id": "d985b408",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "s3_uri = f\"s3://{bucket}/{prefix}\""
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c74ae4ac",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%load -s {s3_uri} -f csv -p OVERSUBSCRIBE --run"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4dd75525",
-   "metadata": {},
-   "source": [
-    "Once the above cell has completed, the data has been loaded into the cluster. We verify the data loaded correctly by running the traversals below to see the count of nodes and edges by label:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 67,
-   "id": "dac8af1d",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6ce6aaf38f694bf9b946a17924ef156c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(Output(layout=Layout(max_height='600px', overflow='scroll', width='100%')), Output(layout=Layout…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%%gremlin\n",
-    "g.V().groupCount().by(label).unfold().order().by(keys)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 68,
-   "id": "e235add5",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "964c84cab1c04fa080af22e56d63e66a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(Output(layout=Layout(max_height='600px', overflow='scroll', width='100%')), Output(layout=Layout…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%%gremlin\n",
-    "g.E().groupCount().by(label).unfold().order().by(keys)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "69229a6e",
-   "metadata": {},
-   "source": [
-    "We can see that all nodes and edges have been loaded to the Neptune cluster!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6476a810",
+   "id": "75f5c5b8",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -2523,9 +883,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_python3",
    "language": "python",
-   "name": "python3"
+   "name": "conda_python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2537,7 +897,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/detect-fake-news-neptune-ml.ipynb
+++ b/detect-fake-news-neptune-ml.ipynb
@@ -28,18 +28,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "c8e71304",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "This Neptune cluster is configured to use Neptune ML\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# import required libraries\n",
     "import boto3\n",
@@ -52,13 +44,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "61fbd6d7",
    "metadata": {},
    "outputs": [],
    "source": [
+    "sess = sagemaker.Session()\n",
+    "bucket = sess.default_bucket()\n",
+    "\n",
     "# S3 location that will be used to store data, processing results and model artifacts\n",
-    "bucket = '<bucket-name>'\n",
+    "bucket = bucket #'<bucket-name>'\n",
     "prefix = 'fake-news-detection'\n",
     "s3_uri = f\"s3://{bucket}/{prefix}\""
    ]
@@ -81,34 +76,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "8eb943d3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': 'healthy',\n",
-       " 'startTime': 'Sat Apr 23 14:55:12 UTC 2022',\n",
-       " 'dbEngineVersion': '',\n",
-       " 'role': 'writer',\n",
-       " 'gremlin': {'version': 'tinkerpop-3.4.11'},\n",
-       " 'sparql': {'version': 'sparql-1.1'},\n",
-       " 'labMode': {'ObjectIndex': 'disabled',\n",
-       "  'DFEQueryEngine': 'viaQueryHint',\n",
-       "  'ReadWriteConflictDetection': 'enabled'},\n",
-       " 'features': {'ResultCache': {'status': 'disabled'},\n",
-       "  'IAMAuthentication': 'disabled',\n",
-       "  'Streams': 'disabled',\n",
-       "  'AuditLog': 'disabled'},\n",
-       " 'settings': {'clusterQueryTimeoutInMs': '7200000'}}"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%status"
    ]
@@ -123,25 +94,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "57b96e80",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0cdb0ae0afb94af78edd59e1a25b9a10",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(Output(layout=Layout(max_height='600px', overflow='scroll', width='100%')), Output(layout=Layout…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%gremlin\n",
     "g.V().groupCount().by(label).unfold().order().by(keys)"
@@ -162,25 +118,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "d52d36d0",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f129f38c13a8412e94bc1581db5c5eac",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(Output(layout=Layout(max_height='600px', overflow='scroll', width='100%')), Output(layout=Layout…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%gremlin\n",
     "g.E().groupCount().by(label).unfold().order().by(keys)"
@@ -212,27 +153,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "0a95c7e2",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6cefd73b85604e9d955ff836089724d2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(Output(layout=Layout(max_height='600px', overflow='scroll', width='100%')), Output(layout=Layout…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "%%gremlin\n",
     "\n",
@@ -250,25 +174,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "cae94561",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0f570306dda4431cad378d1a5d02f0f8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(Output(layout=Layout(max_height='600px', overflow='scroll', width='100%')), Output(layout=Layout…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%gremlin\n",
     "\n",
@@ -286,30 +195,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "0d809d07",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d4e0fa8e73e247b4a2c4a12d276164b0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(Output(layout=Layout(max_height='600px', overflow='scroll', width='100%')), Output(layout=Layout…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%gremlin\n",
     "\n",
     "g.V().has('news', 'news_title', within(\"Jeb Bush to lecture at Harvard this fall\", \"BREAKING: Steps to FORCE FBI Director Comey to Resign In Process – Hearing Decides His Fate Sept 28\")).\n",
     "    valueMap('news_title', 'news_type')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afdc81ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%gremlin -g T.label -p v,inE,outV,outE,inV,outE,inV,oute,inv,ine,outv,ine,outv,ine,outv\n",
+    "\n",
+    "g.V().has('news', 'news_title', within(\"BREAKING: Steps to FORCE FBI Director Comey to Resign In Process – Hearing Decides His Fate Sept 28\"))\n",
+    ".inE(\"wrote\")\n",
+    ".outV()\n",
+    ".outE(\"wrote_for\")\n",
+    ".inV()\n",
+    ".outE(\"published\")\n",
+    ".inV().has('news', 'news_title', within(\"BREAKING: Steps to FORCE FBI Director Comey to Resign In Process – Hearing Decides His Fate Sept 28\"))\n",
+    ".outE(\"spread_by\")\n",
+    ".inV()\n",
+    ".inE(\"follows\")\n",
+    ".outV()\n",
+    ".inE(\"follows\")\n",
+    ".outV()\n",
+    ".inE(\"follows\")\n",
+    ".outV()\n",
+    ".path()\n",
+    ".by(valueMap(true))\n",
+    ".limit(100)"
    ]
   },
   {
@@ -328,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "d9f8987a",
    "metadata": {},
    "outputs": [],
@@ -370,25 +293,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "909b6aa9",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e126fc720b584d62aafd76927de34bbc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%neptune_ml export start --export-url {neptune_ml.get_export_service_host()} --export-iam --wait --store-to export_results\n",
     "${export_params}"
@@ -408,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "f084a487",
    "metadata": {},
    "outputs": [],
@@ -420,7 +328,9 @@
     "--config-file-name training-data-configuration.json\n",
     "--job-id {training_job_name} \n",
     "--s3-input-uri {export_results['outputS3Uri']} \n",
-    "--s3-processed-uri {str(s3_uri)}/preloading \"\"\""
+    "--s3-processed-uri {str(s3_uri)}/preloading\n",
+    "--instance-type ml.c5.9xlarge \n",
+    "\"\"\""
    ]
   },
   {
@@ -428,22 +338,7 @@
    "execution_count": null,
    "id": "27c1a331",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a708cf57dcf74c6ca531e8fcd3c93336",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%neptune_ml dataprocessing start --wait --store-to processing_results {processing_params}"
    ]
@@ -469,17 +364,15 @@
     "--data-processing-id {training_job_name} \n",
     "--instance-type ml.c5.18xlarge\n",
     "--s3-output-uri {str(s3_uri)}/training\n",
-    "--max-hpo-number 20\n",
-    "--max-hpo-parallel 4 \"\"\""
+    "--max-hpo-number 30\n",
+    "--max-hpo-parallel 3 \"\"\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "1af31b2a",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%neptune_ml training start --wait --store-to training_results {training_params}"
@@ -503,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "44b4435c",
    "metadata": {},
    "outputs": [],
@@ -514,156 +407,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "dd233cbf",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of training jobs with valid objective: 20\n",
-      "{'lowest': 0.44440001249313354, 'highest': 0.8888999819755554}\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>dropout</th>\n",
-       "      <th>global-norm</th>\n",
-       "      <th>lr</th>\n",
-       "      <th>num-hidden</th>\n",
-       "      <th>TrainingJobName</th>\n",
-       "      <th>TrainingJobStatus</th>\n",
-       "      <th>FinalObjectiveValue</th>\n",
-       "      <th>TrainingStartTime</th>\n",
-       "      <th>TrainingEndTime</th>\n",
-       "      <th>TrainingElapsedTimeSeconds</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>0.212499</td>\n",
-       "      <td>\"True\"</td>\n",
-       "      <td>0.004484</td>\n",
-       "      <td>\"64\"</td>\n",
-       "      <td>fake-nav-neptune-ml-220423-2137-008-8183199f</td>\n",
-       "      <td>Completed</td>\n",
-       "      <td>0.8889</td>\n",
-       "      <td>2022-04-23 21:42:40+00:00</td>\n",
-       "      <td>2022-04-23 21:43:51+00:00</td>\n",
-       "      <td>71.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <td>0.417023</td>\n",
-       "      <td>\"False\"</td>\n",
-       "      <td>0.003385</td>\n",
-       "      <td>\"128\"</td>\n",
-       "      <td>fake-nav-neptune-ml-220423-2137-001-f9891462</td>\n",
-       "      <td>Stopped</td>\n",
-       "      <td>0.7778</td>\n",
-       "      <td>2022-04-23 21:39:19+00:00</td>\n",
-       "      <td>2022-04-23 21:40:48+00:00</td>\n",
-       "      <td>89.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>0.124452</td>\n",
-       "      <td>\"True\"</td>\n",
-       "      <td>0.004415</td>\n",
-       "      <td>\"16\"</td>\n",
-       "      <td>fake-nav-neptune-ml-220423-2137-003-469b9749</td>\n",
-       "      <td>Completed</td>\n",
-       "      <td>0.7778</td>\n",
-       "      <td>2022-04-23 21:39:11+00:00</td>\n",
-       "      <td>2022-04-23 21:40:33+00:00</td>\n",
-       "      <td>82.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>0.222499</td>\n",
-       "      <td>\"True\"</td>\n",
-       "      <td>0.004283</td>\n",
-       "      <td>\"64\"</td>\n",
-       "      <td>fake-nav-neptune-ml-220423-2137-011-a87cbac7</td>\n",
-       "      <td>Completed</td>\n",
-       "      <td>0.7778</td>\n",
-       "      <td>2022-04-23 21:45:35+00:00</td>\n",
-       "      <td>2022-04-23 21:46:47+00:00</td>\n",
-       "      <td>72.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>0.023261</td>\n",
-       "      <td>\"True\"</td>\n",
-       "      <td>0.007504</td>\n",
-       "      <td>\"64\"</td>\n",
-       "      <td>fake-nav-neptune-ml-220423-2137-004-bc38bb1a</td>\n",
-       "      <td>Completed</td>\n",
-       "      <td>0.7778</td>\n",
-       "      <td>2022-04-23 21:39:19+00:00</td>\n",
-       "      <td>2022-04-23 21:41:07+00:00</td>\n",
-       "      <td>108.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "     dropout global-norm        lr num-hidden  \\\n",
-       "12  0.212499      \"True\"  0.004484       \"64\"   \n",
-       "19  0.417023     \"False\"  0.003385      \"128\"   \n",
-       "17  0.124452      \"True\"  0.004415       \"16\"   \n",
-       "9   0.222499      \"True\"  0.004283       \"64\"   \n",
-       "16  0.023261      \"True\"  0.007504       \"64\"   \n",
-       "\n",
-       "                                 TrainingJobName TrainingJobStatus  \\\n",
-       "12  fake-nav-neptune-ml-220423-2137-008-8183199f         Completed   \n",
-       "19  fake-nav-neptune-ml-220423-2137-001-f9891462           Stopped   \n",
-       "17  fake-nav-neptune-ml-220423-2137-003-469b9749         Completed   \n",
-       "9   fake-nav-neptune-ml-220423-2137-011-a87cbac7         Completed   \n",
-       "16  fake-nav-neptune-ml-220423-2137-004-bc38bb1a         Completed   \n",
-       "\n",
-       "    FinalObjectiveValue         TrainingStartTime           TrainingEndTime  \\\n",
-       "12               0.8889 2022-04-23 21:42:40+00:00 2022-04-23 21:43:51+00:00   \n",
-       "19               0.7778 2022-04-23 21:39:19+00:00 2022-04-23 21:40:48+00:00   \n",
-       "17               0.7778 2022-04-23 21:39:11+00:00 2022-04-23 21:40:33+00:00   \n",
-       "9                0.7778 2022-04-23 21:45:35+00:00 2022-04-23 21:46:47+00:00   \n",
-       "16               0.7778 2022-04-23 21:39:19+00:00 2022-04-23 21:41:07+00:00   \n",
-       "\n",
-       "    TrainingElapsedTimeSeconds  \n",
-       "12                        71.0  \n",
-       "19                        89.0  \n",
-       "17                        82.0  \n",
-       "9                         72.0  \n",
-       "16                       108.0  "
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "full_df = tuner.dataframe()\n",
     "\n",
@@ -699,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "b43f3a68",
    "metadata": {},
    "outputs": [],
@@ -711,25 +458,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "0d566043",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "107d275cfc214ab2a8db7c1d04e3aa6e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%neptune_ml endpoint create --wait --store-to endpoint_results {endpoint_params}"
    ]
@@ -744,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "da7647d1",
    "metadata": {},
    "outputs": [],
@@ -763,25 +495,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "69f1d04d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "02c4a82e79ff4b70b315d7f65f6b25d7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(Output(layout=Layout(max_height='600px', overflow='scroll', width='100%')), Output(layout=Layout…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%gremlin\n",
     "g.with(\"Neptune#ml.endpoint\", \"${endpoint}\").\n",
@@ -791,25 +508,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "6fb74d25",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4151d163d7e347f0ae6418f3aec224c7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(Output(layout=Layout(max_height='600px', overflow='scroll', width='100%')), Output(layout=Layout…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%gremlin\n",
     "g.with(\"Neptune#ml.endpoint\", \"${endpoint}\").\n",
@@ -843,19 +545,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "84f68410",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Endpoint fake-news-detection-1650749255 has been deleted\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "neptune_ml.delete_endpoint(training_job_name)"
    ]

--- a/load-graph-dataset.ipynb
+++ b/load-graph-dataset.ipynb
@@ -1,0 +1,126 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "94cb93cf",
+   "metadata": {},
+   "source": [
+    "## Bulk Load to Neptune "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55819d1c",
+   "metadata": {},
+   "source": [
+    "We use the `%load` magic command which is available as part of the AWS `graph-notebook` to bulk load data to our Neptune database. You can use the `%graph_notebook_config` magic command to see information about the Neptune cluster associated with your graph-notebook, and `%status` magic command to see the status of your Neptune cluster.\n",
+    "\n",
+    "Note: Use [these CloudFormation templates](https://docs.aws.amazon.com/neptune/latest/userguide/machine-learning-quick-start.html) to quickly spin up a `graph-notebook`, an associted Neptune cluster, and set up all the configurations needed to work with Neptune ML in a `graph-notebook`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c7238e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "\n",
+    "sess = sagemaker.Session()\n",
+    "bucket = sess.default_bucket()\n",
+    "bucket = bucket #'<bucket-name>'\n",
+    "prefix = 'fake-news-detection/data'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a30208e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_uri = f\"s3://{bucket}/{prefix}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c050f0eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "732e0a70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load -s {s3_uri} -f csv -p OVERSUBSCRIBE --run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c618610",
+   "metadata": {},
+   "source": [
+    "Once the above cell has completed, the data has been loaded into the cluster. We verify the data loaded correctly by running the traversals below to see the count of nodes and edges by label:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45f1d6e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%gremlin\n",
+    "g.V().groupCount().by(label).unfold().order().by(keys)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05dfec12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%gremlin\n",
+    "g.E().groupCount().by(label).unfold().order().by(keys)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f15c0d23",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Corrected the conversion to gremlin csv format for the user_features and edge weights. Changed the bucket to use sagemaker's default_bucket. Added a visualisation of the fake news graph. Split the loading of data into Neptune into its' own notebook to avoid changing the kernel. Added instructions to the README.md specifying a notebook type with enough memory to use with to run the 'create_graph_dataset.ipynb'. Changed the training jobs to use compute optimised instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
